### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+```markdown
 # A Model Context Protocol Server for Home Assistant
+
+[![smithery badge](https://smithery.ai/badge/@strandbrown/homeassistant-mcp)](https://smithery.ai/server/@strandbrown/homeassistant-mcp)
 
 The server uses the MCP protocol to share access to a local Home Assistant instance with an LLM application.
 
@@ -7,6 +10,16 @@ More about MCP here: https://modelcontextprotocol.io/introduction
 More about Home Assistant here: https://www.home-assistant.io
 
 ## Usage
+
+### Installing via Smithery
+
+To install Home Assistant Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@strandbrown/homeassistant-mcp):
+
+```bash
+npx -y @smithery/cli install @strandbrown/homeassistant-mcp --client claude
+```
+
+### Manual Installation
 
 First build the server
 
@@ -49,3 +62,4 @@ Get one using this guide: https://community.home-assistant.io/t/how-to-get-long-
 - [ ] Testing / writing custom prompts
 - [ ] Testing using resources for high-level context
 - [ ] Test varying tool organization
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-```markdown
 # A Model Context Protocol Server for Home Assistant
 
 [![smithery badge](https://smithery.ai/badge/@strandbrown/homeassistant-mcp)](https://smithery.ai/server/@strandbrown/homeassistant-mcp)
@@ -62,4 +61,3 @@ Get one using this guide: https://community.home-assistant.io/t/how-to-get-long-
 - [ ] Testing / writing custom prompts
 - [ ] Testing using resources for high-level context
 - [ ] Test varying tool organization
-```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Home Assistant Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@strandbrown/homeassistant-mcp

Let me know if any tweaks have to be made!