### PR TITLE
feat: Add MCP-over-HTTP transport and separate auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,37 @@
-NODE_ENV=development
+# ============================================================================
+# Home Assistant MCP Server Configuration
+# ============================================================================
+# Copy this file to .env and configure your values
+
+# =================================
+# Home Assistant Connection (INTERNAL)
+# =================================
+# Your Home Assistant instance URL
 HASS_HOST=http://homeassistant.local:8123
-HASS_TOKEN=your_home_assistant_token
-PORT=3000
+
+# Long-Lived Access Token from Home Assistant
+# Get this from: Home Assistant → Profile → Long-Lived Access Tokens → Create Token
+# SECURITY: This token is used INTERNALLY by the server to communicate with HA.
+# It is NEVER exposed to MCP clients.
+HASS_TOKEN=your_home_assistant_long_lived_access_token
+
+# WebSocket URL for real-time updates (optional, for future use)
 HASS_SOCKET_URL=ws://homeassistant.local:8123/api/websocket
+
+# =================================
+# MCP Server Configuration (EXTERNAL)
+# =================================
+# API key that MCP clients must provide to authenticate
+# Generate a secure key with: openssl rand -base64 32
+# SECURITY: This is what you share with Claude Code and other MCP clients.
+# It does NOT grant direct access to Home Assistant - only to this MCP server.
+MCP_API_KEY=your_generated_api_key_here
+
+# Server port (default: 8124)
+PORT=8124
+
+# =================================
+# Development Settings
+# =================================
+NODE_ENV=development
 LOG_LEVEL=debug

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,9 @@
 # Home Assistant Connection (INTERNAL)
 # =================================
 # Your Home Assistant instance URL
+# Both HASS_HOST and HASS_BASE_URL are supported (either works)
 HASS_HOST=http://homeassistant.local:8123
+# HASS_BASE_URL=http://homeassistant.local:8123  # Alternative (used by @digital-alchemy/hass library)
 
 # Long-Lived Access Token from Home Assistant
 # Get this from: Home Assistant → Profile → Long-Lived Access Tokens → Create Token

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,73 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/sync-upstream.yml'
+  workflow_dispatch:
+    # Allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Summary
+        run: |
+          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Usage:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,59 @@
+name: Sync from Upstream
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    # Allow manual trigger
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/tevonsb/homeassistant-mcp.git || true
+          git fetch upstream
+
+      - name: Sync main branch
+        run: |
+          git checkout main
+
+          # Check if there are upstream changes
+          UPSTREAM_COMMITS=$(git rev-list HEAD..upstream/main --count)
+
+          if [ "$UPSTREAM_COMMITS" -gt 0 ]; then
+            echo "Found $UPSTREAM_COMMITS new commits from upstream"
+
+            # Merge upstream changes
+            git merge upstream/main --no-edit -m "chore: sync from upstream tevonsb/homeassistant-mcp"
+
+            # Push to origin
+            git push origin main
+
+            echo "Successfully synced $UPSTREAM_COMMITS commits from upstream"
+          else
+            echo "Already up to date with upstream"
+          fi
+
+      - name: Summary
+        run: |
+          echo "## Sync Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Upstream: https://github.com/tevonsb/homeassistant-mcp" >> $GITHUB_STEP_SUMMARY
+          echo "- Last sync: $(date -u)" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ RUN npm install
 RUN npm run build
 
 # Expose the port the app runs on
-EXPOSE 3000
+EXPOSE 8124
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8124/health || exit 1
 
 # Start the application
 CMD ["node", "dist/src/index.js"] 

--- a/README.md
+++ b/README.md
@@ -1,97 +1,83 @@
 # Home Assistant MCP Server
 
-A Model Context Protocol (MCP) server that enables AI assistants like Claude to control your Home Assistant smart home through natural language.
+A Model Context Protocol (MCP) server that enables AI assistants like Claude to control your Home Assistant smart home.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20.10.0-green.svg)
 ![TypeScript](https://img.shields.io/badge/typescript-%5E5.0.0-blue.svg)
 
-## What This Does
-
-This server acts as a bridge between AI assistants and your Home Assistant installation:
-
 ```
 ┌─────────────────┐         ┌──────────────────┐         ┌─────────────────┐
-│   Claude Code   │  MCP    │  This MCP Server │  REST   │ Home Assistant  │
-│   Claude App    │ ──────> │  (Port 8124)     │ ──────> │ (Port 8123)     │
-│   Other MCP     │         │                  │         │                 │
-│   Clients       │         │  12 Tools for:   │         │ Your Smart Home │
-└─────────────────┘         │  • Lights        │         └─────────────────┘
-                            │  • Climate       │
-                            │  • Scenes        │
-                            │  • Automations   │
-                            │  • And more...   │
-                            └──────────────────┘
+│   Claude Code   │   MCP   │  This Server     │  REST   │ Home Assistant  │
+│   Claude App    │ ──────► │  (Port 8124)     │ ──────► │ (Port 8123)     │
+└─────────────────┘         └──────────────────┘         └─────────────────┘
 ```
 
 ## Quick Start
 
-### 1. Prerequisites
+### Prerequisites
 
-- **Node.js 20.10.0+** (for `toSorted` support)
-- **Running Home Assistant** instance
+- **Node.js 20.10.0+** or **Docker**
+- **Home Assistant** instance with API access
 - **Long-Lived Access Token** from Home Assistant
 
-### 2. Get Your Home Assistant Token
+### 1. Get Your Home Assistant Token
 
-1. Open Home Assistant in your browser
-2. Go to your Profile (bottom left)
-3. Scroll to "Long-Lived Access Tokens"
-4. Click "Create Token", name it "MCP Server"
-5. **Copy the token immediately** (you won't see it again!)
+1. Open Home Assistant → Profile (bottom left)
+2. Scroll to "Long-Lived Access Tokens"
+3. Click "Create Token", name it "MCP Server"
+4. **Copy immediately** (shown only once)
 
-### 3. Install & Configure
+### 2. Generate an MCP API Key
 
 ```bash
-# Clone and install
-git clone https://github.com/don4of4/homeassistant-mcp.git
+openssl rand -base64 32
+```
+
+This separates client authentication from your HA credentials (see [Security Model](#security-model)).
+
+### 3. Run the Server
+
+**Option A: Docker (Recommended)**
+
+```bash
+docker run -d \
+  --name homeassistant-mcp \
+  -p 8124:8124 \
+  -e HASS_HOST=http://YOUR_HA_IP:8123 \
+  -e HASS_TOKEN=your_ha_token \
+  -e MCP_API_KEY=your_generated_key \
+  ghcr.io/jango-blockchained/homeassistant-mcp:latest
+```
+
+**Option B: From Source**
+
+```bash
+git clone https://github.com/jango-blockchained/homeassistant-mcp.git
 cd homeassistant-mcp
-npm install
+npm install && npm run build
 
-# Configure
-cp .env.example .env
-```
-
-Edit `.env`:
-
-```env
-# Home Assistant (INTERNAL - never share this)
+# Create .env file
+cat > .env << EOF
 HASS_HOST=http://YOUR_HA_IP:8123
-HASS_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
-
-# MCP API Key (EXTERNAL - share with MCP clients)
-# Generate with: openssl rand -base64 32
-MCP_API_KEY=YOUR_GENERATED_API_KEY
-
-# Server port
+HASS_TOKEN=your_ha_token
+MCP_API_KEY=your_generated_key
 PORT=8124
-```
+EOF
 
-### 4. Build & Run
-
-```bash
-# Build
-npm run build
-
-# Run
 npm start
-
-# Or development mode with hot reload
-npm run dev
 ```
 
-The server starts on `http://localhost:8124`. Test it:
+**Verify it's running:**
 
 ```bash
 curl http://localhost:8124/health
 # {"status":"ok","timestamp":"...","version":"0.1.0"}
 ```
 
----
+## Connect Claude
 
-## Client Integration
-
-### Claude Code (HTTP Transport)
+### Claude Code (HTTP)
 
 Add to `~/.claude/mcp.json`:
 
@@ -111,7 +97,7 @@ Add to `~/.claude/mcp.json`:
 
 Restart Claude Code to connect.
 
-### Claude Desktop (stdio Transport)
+### Claude Desktop (stdio)
 
 Add to your Claude Desktop config:
 
@@ -123,154 +109,53 @@ Add to your Claude Desktop config:
       "args": ["/path/to/homeassistant-mcp/dist/src/index.js"],
       "env": {
         "HASS_HOST": "http://YOUR_HA_IP:8123",
-        "HASS_TOKEN": "YOUR_LONG_LIVED_ACCESS_TOKEN",
-        "MCP_API_KEY": "YOUR_GENERATED_API_KEY",
-        "PORT": "8124"
+        "HASS_TOKEN": "your_ha_token",
+        "MCP_API_KEY": "your_generated_key"
       }
     }
   }
 }
 ```
 
----
-
 ## Security Model
 
 This server uses **two separate tokens** for defense in depth:
 
-| Token | Purpose | Who Has It | Security |
-|-------|---------|------------|----------|
-| `HASS_TOKEN` | Server → Home Assistant | **Server only** | Never exposed to clients |
-| `MCP_API_KEY` | Clients → MCP Server | Claude, you | Can be rotated independently |
+| Token | Direction | Purpose |
+|-------|-----------|---------|
+| `HASS_TOKEN` | Server → Home Assistant | Internal only, never exposed to clients |
+| `MCP_API_KEY` | Clients → Server | Shareable, rotate independently from HA |
 
-**Why two tokens?**
-
-- If `MCP_API_KEY` is compromised, revoke it without touching HA
-- `HASS_TOKEN` never leaves the server
-- Clients can't bypass the MCP server to access HA directly
-- Each layer has its own authentication
-
-**Generate a secure API key:**
-
-```bash
-openssl rand -base64 32
-```
-
----
+**Why?** If `MCP_API_KEY` is compromised, revoke it without touching your Home Assistant credentials.
 
 ## Available Tools
 
-The server exposes 12 tools to MCP clients:
+| Tool | Description |
+|------|-------------|
+| `list_devices` | List all Home Assistant devices and entities |
+| `control` | Control lights, switches, covers, climate, media players |
+| `get_history` | Get entity state history |
+| `scene` | List and activate scenes |
+| `automation` | Toggle or trigger automations |
+| `automation_config` | Create and edit automations |
+| `addon` | Manage Home Assistant add-ons |
+| `package` | Manage HACS packages |
+| `notify` | Send notifications |
+| `subscribe_events` | Subscribe to real-time state changes (SSE) |
+| `get_sse_stats` | Get SSE connection statistics |
 
-### Device Control
-
-| Tool | Description | Example Use |
-|------|-------------|-------------|
-| `list_devices` | List all HA devices/entities | "What devices do I have?" |
-| `control` | Control lights, switches, covers, climate | "Turn on the living room lights" |
-| `get_history` | Get entity state history | "What was the temperature yesterday?" |
-
-### Scenes & Automations
-
-| Tool | Description | Example Use |
-|------|-------------|-------------|
-| `scene` | List and activate scenes | "Activate movie night scene" |
-| `automation` | Toggle or trigger automations | "Trigger the morning routine" |
-| `automation_config` | Create/edit automations | "Create an automation for motion" |
-
-### System Management
-
-| Tool | Description | Example Use |
-|------|-------------|-------------|
-| `addon` | Manage HA add-ons | "List installed add-ons" |
-| `package` | Manage HACS packages | "Install a custom integration" |
-| `notify` | Send notifications | "Send me an alert" |
-
-### Real-time Updates
-
-| Tool | Description | Example Use |
-|------|-------------|-------------|
-| `subscribe_events` | Subscribe to state changes | "Watch the front door sensor" |
-| `get_sse_stats` | Get SSE connection statistics | "How many clients connected?" |
-
----
-
-## API Endpoints
-
-### MCP Protocol (for AI clients)
-
-```
-POST /mcp
-Authorization: Bearer YOUR_MCP_API_KEY
-Content-Type: application/json
-
-# Initialize connection
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
-
-# List available tools
-{"jsonrpc":"2.0","id":2,"method":"tools/list"}
-
-# Call a tool
-{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_devices","arguments":{}}}
-```
-
-### REST API (direct access)
-
-```bash
-# Health check (no auth required)
-GET /health
-
-# List devices
-GET /list_devices
-Authorization: Bearer YOUR_MCP_API_KEY
-
-# Control devices
-POST /control
-Authorization: Bearer YOUR_MCP_API_KEY
-Content-Type: application/json
-{"command":"turn_on","entity_id":"light.living_room"}
-
-# Subscribe to events (Server-Sent Events)
-GET /subscribe_events?token=YOUR_MCP_API_KEY&domain=light
-
-# Get SSE statistics
-GET /get_sse_stats?token=YOUR_MCP_API_KEY
-```
-
----
-
-## Docker Deployment
-
-### Quick Start
-
-```bash
-# Build
-docker build -t homeassistant-mcp .
-
-# Run
-docker run -d \
-  --name homeassistant-mcp \
-  -p 8124:8124 \
-  -e HASS_HOST=http://YOUR_HA_IP:8123 \
-  -e HASS_TOKEN=YOUR_HA_TOKEN \
-  -e MCP_API_KEY=YOUR_API_KEY \
-  homeassistant-mcp
-```
-
-### Docker Compose
+## Docker Compose
 
 ```yaml
-version: '3.8'
 services:
   homeassistant-mcp:
-    build: .
+    image: ghcr.io/jango-blockchained/homeassistant-mcp:latest
     ports:
       - "8124:8124"
     environment:
       - HASS_HOST=http://homeassistant:8123
       - HASS_TOKEN=${HASS_TOKEN}
       - MCP_API_KEY=${MCP_API_KEY}
-      - PORT=8124
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8124/health"]
@@ -279,107 +164,33 @@ services:
       retries: 3
 ```
 
----
-
 ## Troubleshooting
 
-### "FATAL: HASS_TOKEN is required"
-
-You need to set your Home Assistant Long-Lived Access Token:
-
-1. Go to Home Assistant → Profile → Long-Lived Access Tokens
-2. Create a token
-3. Add it to your `.env` file as `HASS_TOKEN`
-
-### "FATAL: MCP_API_KEY is required"
-
-Generate an API key for MCP clients:
-
-```bash
-openssl rand -base64 32
-```
-
-Add it to your `.env` file as `MCP_API_KEY`.
-
-### "Unauthorized - Invalid API key"
-
-Your client is using the wrong token. Make sure:
-
-- You're using `MCP_API_KEY` (not `HASS_TOKEN`) in client config
-- The token matches exactly (no extra spaces)
-- You restarted Claude Code after changing config
-
-### Connection refused
-
-1. Check the server is running: `curl http://localhost:8124/health`
-2. Check firewall allows port 8124
-3. If using Docker, ensure port mapping is correct
-
-### Node.js version error ("toSorted is not a function")
-
-Update to Node.js 20.10.0 or higher:
-
-```bash
-nvm install 20.10.0
-nvm use 20.10.0
-```
-
-### Home Assistant connection issues
-
-1. Verify `HASS_HOST` is reachable from the server
-2. Check the token has correct permissions in HA
-3. Ensure HA API is enabled
-
----
+| Error | Solution |
+|-------|----------|
+| `FATAL: HASS_TOKEN is required` | Set your HA Long-Lived Access Token in env |
+| `FATAL: MCP_API_KEY is required` | Generate one: `openssl rand -base64 32` |
+| `Unauthorized - Invalid API key` | Use `MCP_API_KEY` in client config, not `HASS_TOKEN` |
+| Connection refused | Check server is running: `curl http://localhost:8124/health` |
+| `toSorted is not a function` | Update to Node.js 20.10.0+: `nvm install 20` |
+| `fetch failed` on tool calls | Check `HASS_HOST` is reachable from server/container |
 
 ## Development
 
 ```bash
-# Install dependencies
-npm install
-
-# Development mode (hot reload)
-npm run dev
-
-# Build
-npm run build
-
-# Run tests
-npx jest
-
-# Lint
-npm run lint
-
-# Format
-npm run format
+npm install        # Install dependencies
+npm run dev        # Development mode with hot reload
+npm run build      # Build for production
+npm run lint       # Lint code
+npx jest           # Run tests
 ```
-
-### Project Structure
-
-```
-homeassistant-mcp/
-├── src/
-│   ├── index.ts          # Main server, endpoints, MCP handler
-│   ├── security/         # Auth middleware, rate limiting
-│   ├── sse/              # Server-Sent Events manager
-│   ├── hass/             # Home Assistant API client
-│   ├── tools/            # MCP tool implementations
-│   └── types/            # TypeScript type definitions
-├── Dockerfile
-├── .env.example
-└── package.json
-```
-
----
 
 ## License
 
-MIT License - See [LICENSE](LICENSE)
-
----
+MIT - See [LICENSE](LICENSE)
 
 ## Acknowledgments
 
-- [Model Context Protocol](https://modelcontextprotocol.io/) - The protocol specification
-- [Home Assistant](https://www.home-assistant.io/) - The smart home platform
-- [LiteMCP](https://github.com/geekworm/litemcp) - Lightweight MCP server implementation
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Home Assistant](https://www.home-assistant.io/)
+- [@digital-alchemy/hass](https://github.com/Digital-Alchemy-TS/hass)

--- a/README.md
+++ b/README.md
@@ -1,758 +1,385 @@
-# Model Context Protocol Server for Home Assistant
+# Home Assistant MCP Server
 
-The server uses the MCP protocol to share access to a local Home Assistant instance with an LLM application.
-
-A powerful bridge between your Home Assistant instance and Language Learning Models (LLMs), enabling natural language control and monitoring of your smart home devices through the Model Context Protocol (MCP). This server provides a comprehensive API for managing your entire Home Assistant ecosystem, from device control to system administration.
+A Model Context Protocol (MCP) server that enables AI assistants like Claude to control your Home Assistant smart home through natural language.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D20.10.0-green.svg)
-![Docker Compose](https://img.shields.io/badge/docker-compose-%3E%3D1.27.0-blue.svg)
-![NPM](https://img.shields.io/badge/npm-%3E%3D7.0.0-orange.svg)
 ![TypeScript](https://img.shields.io/badge/typescript-%5E5.0.0-blue.svg)
-![Test Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
 
-## Features
+## What This Does
 
-- 🎮 **Device Control**: Control any Home Assistant device through natural language
-- 🔄 **Real-time Updates**: Get instant updates through Server-Sent Events (SSE)
-- 🤖 **Automation Management**: Create, update, and manage automations
-- 📊 **State Monitoring**: Track and query device states
-- 🔐 **Secure**: Token-based authentication and rate limiting
-- 📱 **Mobile Ready**: Works with any HTTP-capable client
+This server acts as a bridge between AI assistants and your Home Assistant installation:
 
-## Real-time Updates with SSE
-
-The server includes a powerful Server-Sent Events (SSE) system that provides real-time updates from your Home Assistant instance. This allows you to:
-
-- 🔄 Get instant state changes for any device
-- 📡 Monitor automation triggers and executions
-- 🎯 Subscribe to specific domains or entities
-- 📊 Track service calls and script executions
-
-### Quick SSE Example
-
-```javascript
-const eventSource = new EventSource(
-  'http://localhost:3000/subscribe_events?token=YOUR_TOKEN&domain=light'
-);
-
-eventSource.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  console.log('Update received:', data);
-};
+```
+┌─────────────────┐         ┌──────────────────┐         ┌─────────────────┐
+│   Claude Code   │  MCP    │  This MCP Server │  REST   │ Home Assistant  │
+│   Claude App    │ ──────> │  (Port 8124)     │ ──────> │ (Port 8123)     │
+│   Other MCP     │         │                  │         │                 │
+│   Clients       │         │  12 Tools for:   │         │ Your Smart Home │
+└─────────────────┘         │  • Lights        │         └─────────────────┘
+                            │  • Climate       │
+                            │  • Scenes        │
+                            │  • Automations   │
+                            │  • And more...   │
+                            └──────────────────┘
 ```
 
-See [SSE_API.md](docs/SSE_API.md) for complete documentation of the SSE system.
+## Quick Start
 
-## Table of Contents
+### 1. Prerequisites
 
-- [Key Features](#key-features)
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
-  - [Basic Setup](#basic-setup)
-  - [Docker Setup (Recommended)](#docker-setup-recommended)
-- [Configuration](#configuration)
-- [Development](#development)
-- [API Reference](#api-reference)
-  - [Device Control](#device-control)
-  - [Add-on Management](#add-on-management)
-  - [Package Management](#package-management)
-  - [Automation Management](#automation-management)
-- [Natural Language Integration](#natural-language-integration)
-- [Troubleshooting](#troubleshooting)
-- [Project Status](#project-status)
-- [Contributing](#contributing)
-- [Resources](#resources)
-- [License](#license)
+- **Node.js 20.10.0+** (for `toSorted` support)
+- **Running Home Assistant** instance
+- **Long-Lived Access Token** from Home Assistant
 
-## Key Features
+### 2. Get Your Home Assistant Token
 
-### Core Functionality 🎮
-- **Smart Device Control**
-  - 💡 **Lights**: Brightness, color temperature, RGB color
-  - 🌡️ **Climate**: Temperature, HVAC modes, fan modes, humidity
-  - 🚪 **Covers**: Position and tilt control
-  - 🔌 **Switches**: On/off control
-  - 🚨 **Sensors & Contacts**: State monitoring
-  - 🎵 **Media Players**: Playback control, volume, source selection
-  - 🌪️ **Fans**: Speed, oscillation, direction
-  - 🔒 **Locks**: Lock/unlock control
-  - 🧹 **Vacuums**: Start, stop, return to base
-  - 📹 **Cameras**: Motion detection, snapshots
+1. Open Home Assistant in your browser
+2. Go to your Profile (bottom left)
+3. Scroll to "Long-Lived Access Tokens"
+4. Click "Create Token", name it "MCP Server"
+5. **Copy the token immediately** (you won't see it again!)
 
-### System Management 🛠️
-- **Add-on Management**
-  - Browse available add-ons
-  - Install/uninstall add-ons
-  - Start/stop/restart add-ons
-  - Version management
-  - Configuration access
-
-- **Package Management (HACS)**
-  - Integration with Home Assistant Community Store
-  - Multiple package types support:
-    - Custom integrations
-    - Frontend themes
-    - Python scripts
-    - AppDaemon apps
-    - NetDaemon apps
-  - Version control and updates
-  - Repository management
-
-- **Automation Management**
-  - Create and edit automations
-  - Advanced configuration options:
-    - Multiple trigger types
-    - Complex conditions
-    - Action sequences
-    - Execution modes
-  - Duplicate and modify existing automations
-  - Enable/disable automation rules
-  - Trigger automation manually
-
-### Architecture Features 🏗️
-- **Intelligent Organization**
-  - Area and floor-based device grouping
-  - State monitoring and querying
-  - Smart context awareness
-  - Historical data access
-
-- **Robust Architecture**
-  - Comprehensive error handling
-  - State validation
-  - Secure API integration
-  - TypeScript type safety
-  - Extensive test coverage
-
-## Prerequisites
-
-- **Node.js** 20.10.0 or higher
-- **NPM** package manager
-- **Docker Compose** for containerization
-- Running **Home Assistant** instance
-- Home Assistant long-lived access token ([How to get token](https://community.home-assistant.io/t/how-to-get-long-lived-access-token/162159))
-- **HACS** installed for package management features
-- **Supervisor** access for add-on management
-
-## Installation
-
-### Basic Setup
+### 3. Install & Configure
 
 ```bash
-# Clone the repository
-git clone https://github.com/tevonsb/homeassistant-mcp.git
+# Clone and install
+git clone https://github.com/don4of4/homeassistant-mcp.git
 cd homeassistant-mcp
-
-# Install dependencies
 npm install
 
-# Build the project
-npm run build
+# Configure
+cp .env.example .env
 ```
 
-### Docker Setup (Recommended)
-
-The project includes Docker support for easy deployment and consistent environments across different platforms.
-
-1. **Clone the repository:**
-    ```bash
-    git clone https://github.com/tevonsb/homeassistant-mcp.git
-    cd homeassistant-mcp
-    ```
-
-2. **Configure environment:**
-    ```bash
-    cp .env.example .env
-    ```
-    Edit the `.env` file with your Home Assistant configuration:
-    ```env
-    # Home Assistant Configuration
-    HASS_HOST=http://homeassistant.local:8123
-    HASS_TOKEN=your_home_assistant_token
-    HASS_SOCKET_URL=ws://homeassistant.local:8123/api/websocket
-
-    # Server Configuration
-    PORT=3000
-    NODE_ENV=production
-    DEBUG=false
-    ```
-
-3. **Build and run with Docker Compose:**
-    ```bash
-    # Build and start the containers
-    docker compose up -d
-
-    # View logs
-    docker compose logs -f
-
-    # Stop the service
-    docker compose down
-    ```
-
-4. **Verify the installation:**
-    The server should now be running at `http://localhost:3000`. You can check the health endpoint at `http://localhost:3000/health`.
-
-5. **Update the application:**
-    ```bash
-    # Pull the latest changes
-    git pull
-
-    # Rebuild and restart the containers
-    docker compose up -d --build
-    ```
-
-#### Docker Configuration
-
-The Docker setup includes:
-- Multi-stage build for optimal image size
-- Health checks for container monitoring
-- Volume mounting for environment configuration
-- Automatic container restart on failure
-- Exposed port 3000 for API access
-
-#### Docker Compose Environment Variables
-
-All environment variables can be configured in the `.env` file. The following variables are supported:
-- `HASS_HOST`: Your Home Assistant instance URL
-- `HASS_TOKEN`: Long-lived access token for Home Assistant
-- `HASS_SOCKET_URL`: WebSocket URL for Home Assistant
-- `PORT`: Server port (default: 3000)
-- `NODE_ENV`: Environment (production/development)
-- `DEBUG`: Enable debug mode (true/false)
-
-## Configuration
-
-### Environment Variables
+Edit `.env`:
 
 ```env
-# Home Assistant Configuration
-HASS_HOST=http://homeassistant.local:8123  # Your Home Assistant instance URL
-HASS_TOKEN=your_home_assistant_token       # Long-lived access token
-HASS_SOCKET_URL=ws://homeassistant.local:8123/api/websocket  # WebSocket URL
+# Home Assistant (INTERNAL - never share this)
+HASS_HOST=http://YOUR_HA_IP:8123
+HASS_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
 
-# Server Configuration
-PORT=3000                # Server port (default: 3000)
-NODE_ENV=production     # Environment (production/development)
-DEBUG=false            # Enable debug mode
+# MCP API Key (EXTERNAL - share with MCP clients)
+# Generate with: openssl rand -base64 32
+MCP_API_KEY=YOUR_GENERATED_API_KEY
 
-# Test Configuration
-TEST_HASS_HOST=http://localhost:8123  # Test instance URL
-TEST_HASS_TOKEN=test_token           # Test token
+# Server port
+PORT=8124
 ```
 
-### Configuration Files
+### 4. Build & Run
 
-1. **Development**: Copy `.env.example` to `.env.development`
-2. **Production**: Copy `.env.example` to `.env.production`
-3. **Testing**: Copy `.env.example` to `.env.test`
+```bash
+# Build
+npm run build
 
-### Adding to Claude Desktop (or other clients)
+# Run
+npm start
 
-To use your new Home Assistant MCP server, you can add Claude Desktop as a client. Add the following to the configuration. Note this will run the MCP within claude and does not work with the Docker method.
-
+# Or development mode with hot reload
+npm run dev
 ```
+
+The server starts on `http://localhost:8124`. Test it:
+
+```bash
+curl http://localhost:8124/health
+# {"status":"ok","timestamp":"...","version":"0.1.0"}
+```
+
+---
+
+## Client Integration
+
+### Claude Code (HTTP Transport)
+
+Add to `~/.claude/mcp.json`:
+
+```json
 {
-  "homeassistant": {
-    "command": "node",
-    "args": [<path/to/your/dist/folder>]
-    "env": {
-      NODE_ENV=development
-      HASS_HOST=http://homeassistant.local:8123
-      HASS_TOKEN=your_home_assistant_token
-      PORT=3000
-      HASS_SOCKET_URL=ws://homeassistant.local:8123/api/websocket
-      LOG_LEVEL=debug
+  "mcpServers": {
+    "home-assistant": {
+      "type": "http",
+      "url": "http://YOUR_SERVER_IP:8124/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_API_KEY"
+      }
     }
   }
 }
-
 ```
 
+Restart Claude Code to connect.
 
+### Claude Desktop (stdio Transport)
 
-## API Reference
+Add to your Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "homeassistant": {
+      "command": "node",
+      "args": ["/path/to/homeassistant-mcp/dist/src/index.js"],
+      "env": {
+        "HASS_HOST": "http://YOUR_HA_IP:8123",
+        "HASS_TOKEN": "YOUR_LONG_LIVED_ACCESS_TOKEN",
+        "MCP_API_KEY": "YOUR_GENERATED_API_KEY",
+        "PORT": "8124"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Security Model
+
+This server uses **two separate tokens** for defense in depth:
+
+| Token | Purpose | Who Has It | Security |
+|-------|---------|------------|----------|
+| `HASS_TOKEN` | Server → Home Assistant | **Server only** | Never exposed to clients |
+| `MCP_API_KEY` | Clients → MCP Server | Claude, you | Can be rotated independently |
+
+**Why two tokens?**
+
+- If `MCP_API_KEY` is compromised, revoke it without touching HA
+- `HASS_TOKEN` never leaves the server
+- Clients can't bypass the MCP server to access HA directly
+- Each layer has its own authentication
+
+**Generate a secure API key:**
+
+```bash
+openssl rand -base64 32
+```
+
+---
+
+## Available Tools
+
+The server exposes 12 tools to MCP clients:
 
 ### Device Control
 
-#### Common Entity Controls
-```json
-{
-  "tool": "control",
-  "command": "turn_on",  // or "turn_off", "toggle"
-  "entity_id": "light.living_room"
-}
+| Tool | Description | Example Use |
+|------|-------------|-------------|
+| `list_devices` | List all HA devices/entities | "What devices do I have?" |
+| `control` | Control lights, switches, covers, climate | "Turn on the living room lights" |
+| `get_history` | Get entity state history | "What was the temperature yesterday?" |
+
+### Scenes & Automations
+
+| Tool | Description | Example Use |
+|------|-------------|-------------|
+| `scene` | List and activate scenes | "Activate movie night scene" |
+| `automation` | Toggle or trigger automations | "Trigger the morning routine" |
+| `automation_config` | Create/edit automations | "Create an automation for motion" |
+
+### System Management
+
+| Tool | Description | Example Use |
+|------|-------------|-------------|
+| `addon` | Manage HA add-ons | "List installed add-ons" |
+| `package` | Manage HACS packages | "Install a custom integration" |
+| `notify` | Send notifications | "Send me an alert" |
+
+### Real-time Updates
+
+| Tool | Description | Example Use |
+|------|-------------|-------------|
+| `subscribe_events` | Subscribe to state changes | "Watch the front door sensor" |
+| `get_sse_stats` | Get SSE connection statistics | "How many clients connected?" |
+
+---
+
+## API Endpoints
+
+### MCP Protocol (for AI clients)
+
+```
+POST /mcp
+Authorization: Bearer YOUR_MCP_API_KEY
+Content-Type: application/json
+
+# Initialize connection
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+
+# List available tools
+{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+
+# Call a tool
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_devices","arguments":{}}}
 ```
 
-#### Light Control
-```json
-{
-  "tool": "control",
-  "command": "turn_on",
-  "entity_id": "light.living_room",
-  "brightness": 128,
-  "color_temp": 4000,
-  "rgb_color": [255, 0, 0]
-}
-```
+### REST API (direct access)
 
-### Add-on Management
-
-#### List Available Add-ons
-```json
-{
-  "tool": "addon",
-  "action": "list"
-}
-```
-
-#### Install Add-on
-```json
-{
-  "tool": "addon",
-  "action": "install",
-  "slug": "core_configurator",
-  "version": "5.6.0"
-}
-```
-
-#### Manage Add-on State
-```json
-{
-  "tool": "addon",
-  "action": "start",  // or "stop", "restart"
-  "slug": "core_configurator"
-}
-```
-
-### Package Management
-
-#### List HACS Packages
-```json
-{
-  "tool": "package",
-  "action": "list",
-  "category": "integration"  // or "plugin", "theme", "python_script", "appdaemon", "netdaemon"
-}
-```
-
-#### Install Package
-```json
-{
-  "tool": "package",
-  "action": "install",
-  "category": "integration",
-  "repository": "hacs/integration",
-  "version": "1.32.0"
-}
-```
-
-### Automation Management
-
-#### Create Automation
-```json
-{
-  "tool": "automation_config",
-  "action": "create",
-  "config": {
-    "alias": "Motion Light",
-    "description": "Turn on light when motion detected",
-    "mode": "single",
-    "trigger": [
-      {
-        "platform": "state",
-        "entity_id": "binary_sensor.motion",
-        "to": "on"
-      }
-    ],
-    "action": [
-      {
-        "service": "light.turn_on",
-        "target": {
-          "entity_id": "light.living_room"
-        }
-      }
-    ]
-  }
-}
-```
-
-#### Duplicate Automation
-```json
-{
-  "tool": "automation_config",
-  "action": "duplicate",
-  "automation_id": "automation.motion_light"
-}
-```
-
-### Core Functions
-
-#### State Management
-```http
-GET /api/state
-POST /api/state
-```
-
-Manages the current state of the system.
-
-**Example Request:**
-```json
-POST /api/state
-{
-  "context": "living_room",
-  "state": {
-    "lights": "on",
-    "temperature": 22
-  }
-}
-```
-
-#### Context Updates
-```http
-POST /api/context
-```
-
-Updates the current context with new information.
-
-**Example Request:**
-```json
-POST /api/context
-{
-  "user": "john",
-  "location": "kitchen",
-  "time": "morning",
-  "activity": "cooking"
-}
-```
-
-### Action Endpoints
-
-#### Execute Action
-```http
-POST /api/action
-```
-
-Executes a specified action with given parameters.
-
-**Example Request:**
-```json
-POST /api/action
-{
-  "action": "turn_on_lights",
-  "parameters": {
-    "room": "living_room",
-    "brightness": 80
-  }
-}
-```
-
-#### Batch Actions
-```http
-POST /api/actions/batch
-```
-
-Executes multiple actions in sequence.
-
-**Example Request:**
-```json
-POST /api/actions/batch
-{
-  "actions": [
-    {
-      "action": "turn_on_lights",
-      "parameters": {
-        "room": "living_room"
-      }
-    },
-    {
-      "action": "set_temperature",
-      "parameters": {
-        "temperature": 22
-      }
-    }
-  ]
-}
-```
-
-### Query Functions
-
-#### Get Available Actions
-```http
-GET /api/actions
-```
-
-Returns a list of all available actions.
-
-**Example Response:**
-```json
-{
-  "actions": [
-    {
-      "name": "turn_on_lights",
-      "parameters": ["room", "brightness"],
-      "description": "Turns on lights in specified room"
-    },
-    {
-      "name": "set_temperature",
-      "parameters": ["temperature"],
-      "description": "Sets temperature in current context"
-    }
-  ]
-}
-```
-
-#### Context Query
-```http
-GET /api/context?type=current
-```
-
-Retrieves context information.
-
-**Example Response:**
-```json
-{
-  "current_context": {
-    "user": "john",
-    "location": "kitchen",
-    "time": "morning",
-    "activity": "cooking"
-  }
-}
-```
-
-### WebSocket Events
-
-The server supports real-time updates via WebSocket connections.
-
-```javascript
-// Client-side connection example
-const ws = new WebSocket('ws://localhost:3000/ws');
-
-ws.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  console.log('Received update:', data);
-};
-```
-
-#### Supported Events
-
-- `state_change`: Emitted when system state changes
-- `context_update`: Emitted when context is updated
-- `action_executed`: Emitted when an action is completed
-- `error`: Emitted when an error occurs
-
-**Example Event Data:**
-```json
-{
-  "event": "state_change",
-  "data": {
-    "previous_state": {
-      "lights": "off"
-    },
-    "current_state": {
-      "lights": "on"
-    },
-    "timestamp": "2024-03-20T10:30:00Z"
-  }
-}
-```
-
-### Error Handling
-
-All endpoints return standard HTTP status codes:
-
-- 200: Success
-- 400: Bad Request
-- 401: Unauthorized
-- 403: Forbidden
-- 404: Not Found
-- 500: Internal Server Error
-
-**Error Response Format:**
-```json
-{
-  "error": {
-    "code": "INVALID_PARAMETERS",
-    "message": "Missing required parameter: room",
-    "details": {
-      "missing_fields": ["room"]
-    }
-  }
-}
-```
-
-### Rate Limiting
-
-The API implements rate limiting to prevent abuse:
-
-- 100 requests per minute per IP for regular endpoints
-- 1000 requests per minute per IP for WebSocket connections
-
-When rate limit is exceeded, the server returns:
-
-```json
-{
-  "error": {
-    "code": "RATE_LIMIT_EXCEEDED",
-    "message": "Too many requests",
-    "reset_time": "2024-03-20T10:31:00Z"
-  }
-}
-```
-
-### Example Usage
-
-#### Using curl
 ```bash
-# Get current state
-curl -X GET \
-  http://localhost:3000/api/state \
-  -H 'Authorization: ApiKey your_api_key_here'
+# Health check (no auth required)
+GET /health
 
-# Execute action
-curl -X POST \
-  http://localhost:3000/api/action \
-  -H 'Authorization: ApiKey your_api_key_here' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "action": "turn_on_lights",
-    "parameters": {
-      "room": "living_room",
-      "brightness": 80
-    }
-  }'
+# List devices
+GET /list_devices
+Authorization: Bearer YOUR_MCP_API_KEY
+
+# Control devices
+POST /control
+Authorization: Bearer YOUR_MCP_API_KEY
+Content-Type: application/json
+{"command":"turn_on","entity_id":"light.living_room"}
+
+# Subscribe to events (Server-Sent Events)
+GET /subscribe_events?token=YOUR_MCP_API_KEY&domain=light
+
+# Get SSE statistics
+GET /get_sse_stats?token=YOUR_MCP_API_KEY
 ```
 
-#### Using JavaScript
-```javascript
-// Execute action
-async function executeAction() {
-  const response = await fetch('http://localhost:3000/api/action', {
-    method: 'POST',
-    headers: {
-      'Authorization': 'ApiKey your_api_key_here',
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      action: 'turn_on_lights',
-      parameters: {
-        room: 'living_room',
-        brightness: 80
-      }
-    })
-  });
-  
-  const data = await response.json();
-  console.log('Action result:', data);
-}
+---
+
+## Docker Deployment
+
+### Quick Start
+
+```bash
+# Build
+docker build -t homeassistant-mcp .
+
+# Run
+docker run -d \
+  --name homeassistant-mcp \
+  -p 8124:8124 \
+  -e HASS_HOST=http://YOUR_HA_IP:8123 \
+  -e HASS_TOKEN=YOUR_HA_TOKEN \
+  -e MCP_API_KEY=YOUR_API_KEY \
+  homeassistant-mcp
 ```
+
+### Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  homeassistant-mcp:
+    build: .
+    ports:
+      - "8124:8124"
+    environment:
+      - HASS_HOST=http://homeassistant:8123
+      - HASS_TOKEN=${HASS_TOKEN}
+      - MCP_API_KEY=${MCP_API_KEY}
+      - PORT=8124
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8124/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+---
+
+## Troubleshooting
+
+### "FATAL: HASS_TOKEN is required"
+
+You need to set your Home Assistant Long-Lived Access Token:
+
+1. Go to Home Assistant → Profile → Long-Lived Access Tokens
+2. Create a token
+3. Add it to your `.env` file as `HASS_TOKEN`
+
+### "FATAL: MCP_API_KEY is required"
+
+Generate an API key for MCP clients:
+
+```bash
+openssl rand -base64 32
+```
+
+Add it to your `.env` file as `MCP_API_KEY`.
+
+### "Unauthorized - Invalid API key"
+
+Your client is using the wrong token. Make sure:
+
+- You're using `MCP_API_KEY` (not `HASS_TOKEN`) in client config
+- The token matches exactly (no extra spaces)
+- You restarted Claude Code after changing config
+
+### Connection refused
+
+1. Check the server is running: `curl http://localhost:8124/health`
+2. Check firewall allows port 8124
+3. If using Docker, ensure port mapping is correct
+
+### Node.js version error ("toSorted is not a function")
+
+Update to Node.js 20.10.0 or higher:
+
+```bash
+nvm install 20.10.0
+nvm use 20.10.0
+```
+
+### Home Assistant connection issues
+
+1. Verify `HASS_HOST` is reachable from the server
+2. Check the token has correct permissions in HA
+3. Ensure HA API is enabled
+
+---
 
 ## Development
 
 ```bash
-# Development mode with hot reload
+# Install dependencies
+npm install
+
+# Development mode (hot reload)
 npm run dev
 
-# Build project
+# Build
 npm run build
 
-# Production mode
-npm run start
-
 # Run tests
-npx jest --config=jest.config.cjs
+npx jest
 
-# Run tests with coverage
-npx jest --coverage
-
-# Lint code
+# Lint
 npm run lint
 
-# Format code
+# Format
 npm run format
 ```
 
-## Troubleshooting
+### Project Structure
 
-### Common Issues
+```
+homeassistant-mcp/
+├── src/
+│   ├── index.ts          # Main server, endpoints, MCP handler
+│   ├── security/         # Auth middleware, rate limiting
+│   ├── sse/              # Server-Sent Events manager
+│   ├── hass/             # Home Assistant API client
+│   ├── tools/            # MCP tool implementations
+│   └── types/            # TypeScript type definitions
+├── Dockerfile
+├── .env.example
+└── package.json
+```
 
-1. **Node.js Version (`toSorted is not a function`)**
-   - **Solution:** Update to Node.js 20.10.0+
-   ```bash
-   nvm install 20.10.0
-   nvm use 20.10.0
-   ```
-
-2. **Connection Issues**
-   - Verify Home Assistant is running
-   - Check `HASS_HOST` accessibility
-   - Validate token permissions
-   - Ensure WebSocket connection for real-time updates
-
-3. **Add-on Management Issues**
-   - Verify Supervisor access
-   - Check add-on compatibility
-   - Validate system resources
-
-4. **HACS Integration Issues**
-   - Verify HACS installation
-   - Check HACS integration status
-   - Validate repository access
-
-5. **Automation Issues**
-   - Verify entity availability
-   - Check trigger conditions
-   - Validate service calls
-   - Monitor execution logs
-
-## Project Status
-
-✅ **Complete**
-- Entity, Floor, and Area access
-- Device control (Lights, Climate, Covers, Switches, Contacts)
-- Add-on management system
-- Package management through HACS
-- Advanced automation configuration
-- Basic state management
-- Error handling and validation
-- Docker containerization
-- Jest testing setup
-- TypeScript integration
-- Environment variable management
-- Home Assistant API integration
-- Project documentation
-
-🚧 **In Progress**
-- WebSocket implementation for real-time updates
-- Enhanced security features
-- Tool organization optimization
-- Performance optimization
-- Resource context integration
-- API documentation generation
-- Multi-platform desktop integration
-- Advanced error recovery
-- Custom prompt testing
-- Enhanced macOS integration
-- Type safety improvements
-- Testing coverage expansion
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Implement your changes
-4. Add tests for new functionality
-5. Ensure all tests pass
-6. Submit a pull request
-
-## Resources
-
-- [MCP Documentation](https://modelcontextprotocol.io/introduction)
-- [Home Assistant Docs](https://www.home-assistant.io)
-- [HA REST API](https://developers.home-assistant.io/docs/api/rest)
-- [HACS Documentation](https://hacs.xyz)
-- [TypeScript Documentation](https://www.typescriptlang.org/docs)
+---
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) file
+MIT License - See [LICENSE](LICENSE)
+
+---
+
+## Acknowledgments
+
+- [Model Context Protocol](https://modelcontextprotocol.io/) - The protocol specification
+- [Home Assistant](https://www.home-assistant.io/) - The smart home platform
+- [LiteMCP](https://github.com/geekworm/litemcp) - Lightweight MCP server implementation

--- a/__tests__/config/env-sync.test.ts
+++ b/__tests__/config/env-sync.test.ts
@@ -1,0 +1,146 @@
+import { jest, describe, beforeEach, afterEach, it, expect } from '@jest/globals';
+
+describe('Environment Variable Synchronization', () => {
+    // Backup the original environment
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+        // Clear relevant env vars before each test
+        delete process.env.HASS_HOST;
+        delete process.env.HASS_BASE_URL;
+        delete process.env.HASS_TOKEN;
+        delete process.env.HASS_SOCKET_URL;
+        // Clear module cache to re-run env sync logic
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        // Restore original environment
+        process.env = { ...originalEnv };
+    });
+
+    describe('HASS_HOST and HASS_BASE_URL sync', () => {
+        it('should sync HASS_HOST to HASS_BASE_URL when only HASS_HOST is set', () => {
+            const testUrl = 'http://10.0.1.101:8123';
+            process.env.HASS_HOST = testUrl;
+
+            // Simulate the sync logic from index.ts
+            if (process.env.HASS_HOST && !process.env.HASS_BASE_URL) {
+                process.env.HASS_BASE_URL = process.env.HASS_HOST;
+            }
+
+            expect(process.env.HASS_BASE_URL).toBe(testUrl);
+            expect(process.env.HASS_HOST).toBe(testUrl);
+        });
+
+        it('should sync HASS_BASE_URL to HASS_HOST when only HASS_BASE_URL is set', () => {
+            const testUrl = 'http://192.168.1.100:8123';
+            process.env.HASS_BASE_URL = testUrl;
+
+            // Simulate the sync logic from index.ts
+            if (process.env.HASS_BASE_URL && !process.env.HASS_HOST) {
+                process.env.HASS_HOST = process.env.HASS_BASE_URL;
+            }
+
+            expect(process.env.HASS_HOST).toBe(testUrl);
+            expect(process.env.HASS_BASE_URL).toBe(testUrl);
+        });
+
+        it('should preserve both values when both are set', () => {
+            const hostUrl = 'http://host.local:8123';
+            const baseUrl = 'http://base.local:8123';
+            process.env.HASS_HOST = hostUrl;
+            process.env.HASS_BASE_URL = baseUrl;
+
+            // Simulate the sync logic - should not overwrite
+            if (process.env.HASS_HOST && !process.env.HASS_BASE_URL) {
+                process.env.HASS_BASE_URL = process.env.HASS_HOST;
+            }
+            if (process.env.HASS_BASE_URL && !process.env.HASS_HOST) {
+                process.env.HASS_HOST = process.env.HASS_BASE_URL;
+            }
+
+            expect(process.env.HASS_HOST).toBe(hostUrl);
+            expect(process.env.HASS_BASE_URL).toBe(baseUrl);
+        });
+
+        it('should leave both undefined when neither is set', () => {
+            // Don't set either env var
+
+            // Simulate the sync logic
+            if (process.env.HASS_HOST && !process.env.HASS_BASE_URL) {
+                process.env.HASS_BASE_URL = process.env.HASS_HOST;
+            }
+            if (process.env.HASS_BASE_URL && !process.env.HASS_HOST) {
+                process.env.HASS_HOST = process.env.HASS_BASE_URL;
+            }
+
+            expect(process.env.HASS_HOST).toBeUndefined();
+            expect(process.env.HASS_BASE_URL).toBeUndefined();
+        });
+    });
+
+    describe('HASS_CONFIG', () => {
+        it('should use HASS_BASE_URL when set', async () => {
+            const testUrl = 'http://baseurl.test:8123';
+            process.env.HASS_BASE_URL = testUrl;
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.BASE_URL).toBe(testUrl);
+        });
+
+        it('should use HASS_HOST when HASS_BASE_URL is not set', async () => {
+            const testUrl = 'http://hosturl.test:8123';
+            process.env.HASS_HOST = testUrl;
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.BASE_URL).toBe(testUrl);
+        });
+
+        it('should prefer HASS_BASE_URL over HASS_HOST when both are set', async () => {
+            const baseUrl = 'http://baseurl.preferred:8123';
+            const hostUrl = 'http://hosturl.fallback:8123';
+            process.env.HASS_BASE_URL = baseUrl;
+            process.env.HASS_HOST = hostUrl;
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.BASE_URL).toBe(baseUrl);
+        });
+
+        it('should use default when neither env var is set', async () => {
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.BASE_URL).toBe('http://homeassistant.local:8123');
+        });
+
+        it('should derive SOCKET_URL from BASE_URL', async () => {
+            const testUrl = 'http://socket.test:8123';
+            process.env.HASS_BASE_URL = testUrl;
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.SOCKET_URL).toBe('ws://socket.test:8123/api/websocket');
+        });
+
+        it('should use explicit HASS_SOCKET_URL when provided', async () => {
+            const baseUrl = 'http://base.test:8123';
+            const socketUrl = 'ws://custom-socket.test:8123/api/websocket';
+            process.env.HASS_BASE_URL = baseUrl;
+            process.env.HASS_SOCKET_URL = socketUrl;
+            process.env.HASS_TOKEN = 'test-token';
+
+            const { HASS_CONFIG } = await import('../../src/config/hass.config.js');
+
+            expect(HASS_CONFIG.SOCKET_URL).toBe(socketUrl);
+        });
+    });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -28,7 +28,8 @@ module.exports = {
         '**/__tests__/helpers.test.ts',
         '**/__tests__/schemas/devices.test.ts',
         '**/__tests__/context/index.test.ts',
-        '**/__tests__/hass/index.test.ts'
+        '**/__tests__/hass/index.test.ts',
+        '**/__tests__/config/env-sync.test.ts'
     ],
     globals: {
         'ts-jest': {

--- a/src/config/hass.config.ts
+++ b/src/config/hass.config.ts
@@ -3,9 +3,12 @@ import dotenv from 'dotenv';
 // Load environment variables
 dotenv.config();
 
+// Support both HASS_BASE_URL (library convention) and HASS_HOST (documented)
+const baseUrl = process.env.HASS_BASE_URL || process.env.HASS_HOST || 'http://homeassistant.local:8123';
+
 export const HASS_CONFIG = {
-    BASE_URL: process.env.HASS_HOST || 'http://homeassistant.local:8123',
+    BASE_URL: baseUrl,
     TOKEN: process.env.HASS_TOKEN || '',
-    SOCKET_URL: process.env.HASS_SOCKET_URL || '',
+    SOCKET_URL: process.env.HASS_SOCKET_URL || `${baseUrl.replace(/^http/, 'ws')}/api/websocket`,
     SOCKET_TOKEN: process.env.HASS_TOKEN || '',
 }; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,15 @@ const envFile = process.env.NODE_ENV === 'production'
 console.log(`Loading environment from ${envFile}`);
 config({ path: resolve(process.cwd(), envFile) });
 
+// Sync env vars: support both HASS_HOST (documented) and HASS_BASE_URL (library expects)
+// Must happen before importing hass module which triggers library initialization
+if (process.env.HASS_HOST && !process.env.HASS_BASE_URL) {
+  process.env.HASS_BASE_URL = process.env.HASS_HOST;
+}
+if (process.env.HASS_BASE_URL && !process.env.HASS_HOST) {
+  process.env.HASS_HOST = process.env.HASS_BASE_URL;
+}
+
 import { get_hass } from './hass/index.js';
 import { LiteMCP } from 'litemcp';
 import { z } from 'zod';

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -127,8 +127,8 @@ export class TokenManager {
 
 // Request validation middleware
 export function validateRequest(req: Request, res: Response, next: NextFunction) {
-    // Skip validation for health endpoint
-    if (req.path === '/health') {
+    // Skip validation for health and MCP endpoints (they handle their own validation)
+    if (req.path === '/health' || req.path === '/mcp') {
         return next();
     }
 

--- a/src/sse/index.ts
+++ b/src/sse/index.ts
@@ -264,8 +264,8 @@ export class SSEManager extends EventEmitter {
 
     private validateToken(token?: string): boolean {
         if (!token) return false;
-        // Compare with HASS_TOKEN from environment
-        return token === process.env.HASS_TOKEN;
+        // Compare with MCP_API_KEY from environment (NOT HASS_TOKEN - that's internal only)
+        return token === process.env.MCP_API_KEY;
     }
 
     // Utility methods


### PR DESCRIPTION
## Summary

- Add `POST /mcp` endpoint for HTTP-based MCP clients (Claude Code)
- Separate authentication: `HASS_TOKEN` (internal) vs `MCP_API_KEY` (external)
- Change default port from 3000 to 8124
- Add healthcheck to Dockerfile
- Clean up README (49% smaller, better organized)

## Security Improvement

Introduces two-token architecture for defense in depth:

| Token | Direction | Purpose |
|-------|-----------|---------|
| `HASS_TOKEN` | Server → HA | Internal only, never exposed |
| `MCP_API_KEY` | Clients → Server | Rotatable independently |

## Breaking Changes

- New `MCP_API_KEY` environment variable required
- Default port changed to 8124

## Test Plan

- [x] Server builds and starts
- [x] `/health` endpoint responds
- [x] `/mcp` endpoint authenticates with MCP_API_KEY
- [x] `/mcp` returns tools list via JSON-RPC
- [x] Docker image builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>